### PR TITLE
Explicitly require active_record

### DIFF
--- a/lib/deep_cloning.rb
+++ b/lib/deep_cloning.rb
@@ -1,3 +1,5 @@
+require 'active_record'
+
 # DeepCloning
 
 module DeepCloning


### PR DESCRIPTION
Without this `bundle console` will fail on a Gemfile such as this:

```ruby
source "https://rubygems.org"
gem "rails", "=4.2.7.1" 
gem "deep_cloning"
```

I reproduced the bug on the following system:
Ubuntu 16.04 (within docker)
Rubygems 2.6.2
Bundler 1.13.6